### PR TITLE
wcmValidateDevice: changed __u16 to uint16_t

### DIFF
--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdint.h>
 
 struct checkData {
 	dev_t min_maj;
@@ -128,7 +129,7 @@ ret:
 static struct
 {
 	const char* type;
-	__u16 tool[5]; /* tool array is terminated by 0 */
+	uint16_t tool[5]; /* tool array is terminated by 0 */
 } wcmType [] =
 {
 	{ "stylus", { BTN_TOOL_PEN,       0                  } },


### PR DESCRIPTION
Another issue found while porting!

__u16 is non portable and causes an error on FreeBSD.
Replaced it with uint16_t from the C99 stdint.h.

Thanks!