### PR TITLE
revert "drop wcmLog()" and fix the function instead

### DIFF
--- a/src/x11/xf86Wacom.c
+++ b/src/x11/xf86Wacom.c
@@ -64,6 +64,17 @@ log_sigsafe(WacomLogType type, const char *format, va_list args)
 	LogVMessageVerbSigSafe(xtype, -1, format, args);
 }
 
+void
+wcmLog(WacomDevicePtr priv, WacomLogType type, const char *format, ...)
+{
+	MessageType xtype = (MessageType)type;
+	va_list args;
+
+	va_start(args, format);
+	xf86VIDrvMsgVerb(priv->frontend, xtype, 0, format, args);
+	va_end(args);
+}
+
 void wcmLogSafe(WacomDevicePtr priv, WacomLogType type, const char *format, ...)
 {
 	va_list args;
@@ -339,7 +350,7 @@ void wcmQueueHotplug(WacomDevicePtr priv, const char* name, const char *type, un
 
 	if (!hotplug_info)
 	{
-		xf86IDrvMsgVerb(priv->frontend, (MessageType)W_ERROR, 0, "OOM, cannot hotplug dependent devices\n");
+		wcmLog(priv, W_ERROR, "OOM, cannot hotplug dependent devices\n");
 		return;
 	}
 
@@ -662,7 +673,7 @@ int wcmOpen(WacomDevicePtr priv)
 	if (fd < 0)
 	{
 		int saved_errno = errno;
-		xf86IDrvMsgVerb(priv->frontend, (MessageType)W_ERROR, 0, "Error opening %s (%s)\n",
+		wcmLog(priv, W_ERROR, "Error opening %s (%s)\n",
 			common->device_path, strerror(errno));
 		return -saved_errno;
 	}
@@ -692,7 +703,7 @@ static int wcmReady(WacomDevicePtr priv)
 	int n = xf86WaitForInput(pInfo->fd, 0);
 	if (n < 0) {
 		int saved_errno = errno;
-		xf86IDrvMsgVerb(priv->frontend, (MessageType)W_ERROR, 0, "select error: %s\n", strerror(errno));
+		wcmLog(priv, W_ERROR, "select error: %s\n", strerror(errno));
 		return -saved_errno;
 	} else {
 		DBG(10, priv, "%d numbers of data\n", n);
@@ -811,7 +822,7 @@ static int wcmDevProc(DeviceIntPtr pWcm, int what)
 			break;
 #endif
 		default:
-			xf86IDrvMsgVerb(priv->frontend, (MessageType)W_ERROR, 0,
+			wcmLog(priv, W_ERROR,
 				    "invalid mode=%d. This is an X server bug.\n", what);
 			goto out;
 	} /* end switch */
@@ -1082,7 +1093,7 @@ void
 valuator_mask_set_double(ValuatorMask *mask, int valuator, double data)
 {
 	if (mask->has_unaccelerated) {
-		xf86IDrvMsgVerb(NULL, 0, 0, "Do not mix valuator types, zero mask first\n");
+		wcmLog(null, 0, "Do not mix valuator types, zero mask first\n");
 	}
 	_valuator_mask_set_double(mask, valuator, data);
 }

--- a/src/x11/xf86Wacom.c
+++ b/src/x11/xf86Wacom.c
@@ -71,7 +71,7 @@ wcmLog(WacomDevicePtr priv, WacomLogType type, const char *format, ...)
 	va_list args;
 
 	va_start(args, format);
-	xf86VIDrvMsgVerb(priv->frontend, xtype, 0, format, args);
+	xf86IDrvMsgVerb(priv->frontend, (MessageType)xtype, 0, format, args);
 	va_end(args);
 }
 

--- a/src/x11/xf86WacomProperties.c
+++ b/src/x11/xf86WacomProperties.c
@@ -609,7 +609,7 @@ wcmSetHWTouchProperty(WacomDevicePtr priv)
 	rc = XIGetDeviceProperty(pInfo->dev, prop_hardware_touch, &prop);
 	if (rc != Success || prop->format != 8 || prop->size != 1)
 	{
-		xf86IDrvMsgVerb(priv->frontend, (MessageType)W_ERROR, 0, "Failed to update hardware touch state.\n");
+		wcmLog(priv, W_ERROR, "Failed to update hardware touch state.\n");
 		return;
 	}
 
@@ -1033,7 +1033,7 @@ wcmSetSerialProperty(WacomDevicePtr priv)
 	rc = XIGetDeviceProperty(pInfo->dev, prop_serials, &prop);
 	if (rc != Success || prop->format != 32 || prop->size != 5)
 	{
-		xf86IDrvMsgVerb(priv->frontend, (MessageType)W_ERROR, 0, "Failed to update serial number.\n");
+		wcmLog(priv, W_ERROR, "Failed to update serial number.\n");
 		return;
 	}
 


### PR DESCRIPTION
the guy who decided to remove the wcmLog function did it in a dirty way and didn't finish the job, resulting in the driver not being able to launch (issue #4 )

the point was to remove xf86VIDrvMsgVerb() which has been unexported, this pull request does that in a way that actually work